### PR TITLE
Do not hardcode origin URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ localtext/
 yarn-error.log
 npm-debug.log
 debug.log
+.env

--- a/env.build.txt
+++ b/env.build.txt
@@ -1,0 +1,1 @@
+DATA_URL=https://snowyivu.github.io/ShinyColors

--- a/env.sample.txt
+++ b/env.sample.txt
@@ -1,0 +1,1 @@
+DATA_URL=http://localhost:15944/

--- a/env.txt
+++ b/env.txt
@@ -1,0 +1,1 @@
+DATA_URL=http://localhost:15944/

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "core-js": "3",
+    "dotenv": "^8.2.0",
     "lodash": "^4.17.13",
     "papaparse": "^4.6.3"
   },

--- a/script/build.js
+++ b/script/build.js
@@ -3,7 +3,8 @@ const { version } = require('../package.json')
 const json = require('rollup-plugin-json')
 const resolve = require('rollup-plugin-node-resolve')
 const cmjs = require('rollup-plugin-commonjs')
-
+const path = require('path')
+require('dotenv').config({ path: path.resolve(process.cwd(), 'env.txt') })
 const banner = `// ==UserScript==
 // @name         ShinyColorsEng
 // @namespace    https://github.com/snowyivu/ShinyColors
@@ -40,6 +41,7 @@ module.exports = {
     name: 'shinycolors_eng',
     banner: banner,
     intro: `const ENVIRONMENT = "${process.env.BUILD === 'development' ? 'development' : ''}";
+    const DATA_URL = ${process.env.DATA_URL ? process.env.DATA_URL : ''};
     const DEV = ${process.env.DEV ? true : false};
     const SHOW_UPDATE_TEXT = ${process.env.TEXT ? true : false};
     const COLLECT_CARD_RATE = ${process.env.CARD ? true : false};`

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ const MODULE_ID = {
 const PREVIEW_COUNT = 5
 
 const config = {
-  origin: '',
+  origin: DATA_URL,
   hash: '',
   localHash: '',
   version: version,
@@ -68,9 +68,6 @@ const getLocalConfig = () => {
   })
 
   setFont()
-  if (DEV) {
-    config.origin = 'http://localhost:15944'
-  }
 }
 
 const saveConfig = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,6 +1082,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"


### PR DESCRIPTION
URLs should not be hardcoded in code, instead it needs to be specified on build time.

To accomplish this, a build-time environment file is required, which is done by adding `dotenv` as a dependency.

After merging this, copy env.build.txt to env.txt, then run yarn build and yarn data as usual.