### PR TITLE
Move some etc files directly to data root and gitignore env.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ localtext/
 yarn-error.log
 npm-debug.log
 debug.log
-.env
+env.txt

--- a/env.txt
+++ b/env.txt
@@ -1,1 +1,0 @@
-DATA_URL=https://snowyivu.github.io/ShinyColors

--- a/script/deploy.js
+++ b/script/deploy.js
@@ -52,8 +52,6 @@ const getDate = (offset = 0) => {
   return `${year}/${month}/${date} ${h}:${m}:${sec}.${msec}`
 }
 
-const etcFiles = ['image', 'item', 'mission', 'support-skill', 'mission-re']
-
 const start = async () => {
   await fse.emptyDir('./dist/data/')
   const hash = await md5Dir('./data/')
@@ -90,9 +88,6 @@ const start = async () => {
   console.log('move data files...')
   await fse.copy('./data/', './dist/data/')
   console.log('move etc...')
-  for (let fileName of etcFiles) {
-    await fse.move(`./dist/data/etc/${fileName}.csv`, `./dist/data/${fileName}.csv`, { overwrite: true })
-  }
   if (process.env.PUBLISH === 'skip') {
     console.log('data prepared')
     return


### PR DESCRIPTION
Our translation data currently places some files in the data folder, while the build script expects them to be in data/etc

For simplicity, this commit will place those files directly in data folder, and remove the logic handling the former location at data/etc.

Also, env.txt is deleted and gitignore'd due to a mistake in a previous PR.

Please recopy env.build.txt to env.txt after this change, since env.txt will be deleted and gitignore'd :)