### PR TITLE
Gitignore env and build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ localtext/
 yarn-error.log
 npm-debug.log
 debug.log
-.env
+env.txt

--- a/env.txt
+++ b/env.txt
@@ -1,1 +1,0 @@
-DATA_URL=https://snowyivu.github.io/ShinyColors

--- a/script/build.js
+++ b/script/build.js
@@ -41,7 +41,7 @@ module.exports = {
     name: 'shinycolors_eng',
     banner: banner,
     intro: `const ENVIRONMENT = "${process.env.BUILD === 'development' ? 'development' : ''}";
-    const DATA_URL = ${process.env.DATA_URL ? process.env.DATA_URL : ''};
+    const DATA_URL = '${process.env.DATA_URL ? process.env.DATA_URL : ''}';
     const DEV = ${process.env.DEV ? true : false};
     const SHOW_UPDATE_TEXT = ${process.env.TEXT ? true : false};
     const COLLECT_CARD_RATE = ${process.env.CARD ? true : false};`


### PR DESCRIPTION
This commit fixes env.txt being not ignored by git, which it should have due to it being a build-time configuration.

Please recopy env.build.txt to env.txt after this commit.