### PR TITLE
Decouple fixModule from manifest fetching and fix mission translation…

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import requestHook from './modules/request'
 import resourceHook from './modules/resourse'
 import transScenario from './modules/scenario'
 import addFont from './utils/fontFace'
+import fixModule from './utils/fixModule'
 import './utils/keepBgm'
 import { log, sleep } from './utils/index'
 
@@ -20,6 +21,8 @@ const main = async () => {
     log(e)
   }
 }
+
+fixModule();
 
 let waitCount = 0
 const start = async () => {

--- a/src/modules/get-module.js
+++ b/src/modules/get-module.js
@@ -61,7 +61,6 @@ const getRequest = async () => {
   let md = await getModule('REQUEST', (module) => {
     return module.get && module.post && module.put && module.patch
   })
-  md = Object.assign({}, md)
   return md
 }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,5 +1,4 @@
 import config from '../config'
-import fixModule from './fixModule'
 
 const { origin } = config
 
@@ -61,7 +60,6 @@ const getHash = new Promise((rev, rej) => {
     fetchInfo.data = data
     config.newVersion = data.version
     config.hashes = data.hashes
-    fixModule(data.moduleId.INJECT)
     rev(data)
   }).catch(rej)
 })

--- a/src/utils/fixModule.js
+++ b/src/utils/fixModule.js
@@ -1,16 +1,15 @@
-const fixModule = (param = {}) => {
-  let source = "var n=window.csobb3pncbpccs;"
-  let result = "var n=window.csobb3pncbpccs;window._require=t;"
-  
-  if (param.source) source = param.source
-  if (param.result) result = param.result
+const fixModule = () => {
+  let source = ["var n=window.csobb3pncbpccs;", "Object.freeze({addHeader:"]
+  let result = ["var n=window.csobb3pncbpccs;window._require=t;", "({addHeader:"]
 
   const win = window.unsafeWindow || window
 
   win.eval = new Proxy(win.eval, {
     apply(target, context, args) {
-      if (args[0] && args[0].includes(source)) {
-        args[0] = args[0].replace(source, result)
+      for (let i = 0; i < source.length; i++) {
+        if (args[0] && args[0].includes(source[i])) {
+          args[0] = args[0].replace(source[i], result[i])
+        }
       }
       return Reflect.apply(target, context, args)
     }


### PR DESCRIPTION
The latest way of patching the game's code involved loading manifest.json first
before the game can be patched.

However, if the game loads first before the patching can occur, we're out of
luck. Because of this, fixModule needs to be run very early, before the game
even loads.

This commit decouples fixModule from the manifest loading, so it can always
load before Shiny. This comes with the cost of having to update the script
every new game update, however the relevant code needs to be run as early as
possible, and the only way we can ensure it is to incorporate it in the script
itself.

This commit also incorporates [this commit from the Chinese patch](https://github.com/biuuu/ShinyColors/commit/a0d9bc39324420b05ba0ba6921223834bb6a4e7b)
that fixes the request module to enable other translations.